### PR TITLE
[BAK] 루틴 추가 후 메인복귀시 리셋 #472

### DIFF
--- a/reactnative/Etc.tsx
+++ b/reactnative/Etc.tsx
@@ -163,7 +163,12 @@ const RoutineNameBox: React.FC<RoutineAddProps> = ({
             [
               {
                 text: '확인',
-                onPress: () => navigation.navigate('Main'),
+                onPress: () => {
+                  navigation.reset({
+                    index: 0,
+                    routes: [{name: 'Main'}],
+                  });
+                },
               },
             ],
           );

--- a/reactnative/Health.tsx
+++ b/reactnative/Health.tsx
@@ -231,7 +231,12 @@ const RoutineNameBox: React.FC<RoutineAddProps> = ({
             [
               {
                 text: '확인',
-                onPress: () => navigation.navigate('Main'),
+                onPress: () => {
+                  navigation.reset({
+                    index: 0,
+                    routes: [{name: 'Main'}],
+                  });
+                },
               },
             ],
           );

--- a/reactnative/pill.tsx
+++ b/reactnative/pill.tsx
@@ -189,7 +189,12 @@ const RoutineNameBox: React.FC<RoutineAddProps> = ({
             [
               {
                 text: '확인',
-                onPress: () => navigation.navigate('Main'),
+                onPress: () => {
+                  navigation.reset({
+                    index: 0,
+                    routes: [{name: 'Main'}],
+                  });
+                },
               },
             ],
           );


### PR DESCRIPTION
루틴 추가 페이지에서 추가하기 클릭시 메인화면으로 가는데,
화면을 한번 더 눌러야 루틴리스트가 보였던 부분 수정